### PR TITLE
Move to PauliMeasure

### DIFF
--- a/qiskit/circuit/measure.py
+++ b/qiskit/circuit/measure.py
@@ -95,9 +95,6 @@ class PauliMeasure(Measure):
         self.basis_transformation = basis_transformation
 
     def _define(self):
-        if self.basis == 'z':
-            return
-
         definition = []
         q = QuantumRegister(1, 'q')
         c = ClassicalRegister(1, 'c')

--- a/qiskit/circuit/measure.py
+++ b/qiskit/circuit/measure.py
@@ -43,7 +43,7 @@ class Measure(Instruction):
             raise CircuitError('register size error')
 
 
-def measure_z(self, qubit, cbit):
+def measure(self, qubit, cbit):
     """Measure quantum bit into classical bit (tuples).
 
     Args:


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

Renamed the base class to `PauliMeasure` and removed the logic for general basis changes. If there's no requirement for automating arbitrary basis transformations we don't have to add it (called the "you're-not-gonna-need-it" paradigm 😉). Also inherit from `Measure` to avoid some code duplication.


